### PR TITLE
MAYH-5903 Add non-service indexing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -74,3 +74,11 @@ __pycache*
 
 # transient librdkafka
 .librdkafka
+
+/*.xml
+/*.ib
+/*.bp
+/*.idx
+/*.gz
+/*.blank
+

--- a/attackstream-indexer.cabal
+++ b/attackstream-indexer.cabal
@@ -83,11 +83,12 @@ library
                       , App.AppState
                       , App.AWS.S3
                       , App.FileChange
+                      , App.Index
+                      , App.IndexFile
                       , App.Kafka
                       , App.Options
                       , App.Orphans
                       , App.Submissions
-                      , App.IndexFile
   default-language:     Haskell2010
   ghc-options:          -Wall
   build-depends:        base >= 4.7 && < 5
@@ -101,6 +102,7 @@ library
                       , bytestring
                       , bytestring-conversion
                       , conduit
+                      , conduit-combinators
                       , conduit-extra
                       , containers
                       , datadog

--- a/docker/start.sh
+++ b/docker/start.sh
@@ -10,7 +10,7 @@ export STATSD_HOST=${STATSD_HOST:-$GATEWAY_IP}
 /usr/local/bin/set-environment
 
 set -x
-attackstream-indexer \
+attackstream-indexer service \
   ${AWS_REGION+                       --region                            "${AWS_REGION}"                       } \
   ${KAFKA_BROKER+                     --kafka-broker                      "${KAFKA_BROKER}"                     } \
   ${KAFKA_GROUP_ID+                   --kafka-group-id                    "${KAFKA_GROUP_ID}"                   } \

--- a/run.sh
+++ b/run.sh
@@ -9,7 +9,7 @@ echo "Running: $exe"
 stack build
 path=$(stack path --local-install-root)
 
-${path}/bin/${exe} \
+${path}/bin/${exe} service \
   --kafka-broker ${KAFKA_HOST}:9092 \
   --kafka-schema-registry http://${KAFKA_HOST}:8081 \
   --kafka-group-id ${CLUB_NAME}--submissions-indexer-group-${USER} \

--- a/src/App/AppOptions.hs
+++ b/src/App/AppOptions.hs
@@ -7,7 +7,7 @@ import Control.Lens
 import Network.StatsD (StatsClient)
 
 data AppOptions = AppOptions
-  { _appOpts        :: Options
+  { _appOpts        :: ServiceOptions
   , _appStatsClient :: StatsClient
   }
 

--- a/src/App/Application.hs
+++ b/src/App/Application.hs
@@ -71,7 +71,7 @@ deriving instance MonadApp Application
 instance MonadStats Application where
   getStatsClient = reader _appStatsClient
 
-runApplication :: HasEnv e => AppName -> e -> Options -> Application () -> IO AppState
+runApplication :: HasEnv e => AppName -> e -> ServiceOptions -> Application () -> IO AppState
 runApplication appName e opt val =
   runResourceT . runAWS e . runLogT' (opt ^. optLogLevel) . flip execStateT appStateEmpty $ do
     logInfo $ show opt
@@ -83,7 +83,7 @@ runApplication appName e opt val =
 
     runReaderT (unApp val) (AppOptions opt stats)
 
-statsTags :: MonadIO m => Options -> m [Tag]
+statsTags :: MonadIO m => ServiceOptions -> m [Tag]
 statsTags opts = liftIO $ do
   deplId <- envTag "TASK_DEPLOY_ID" "deploy_id"
   let envTags = catMaybes [deplId]

--- a/src/App/Index.hs
+++ b/src/App/Index.hs
@@ -1,0 +1,86 @@
+{-# LANGUAGE BangPatterns #-}
+
+module App.Index where
+
+import App
+import Data.Conduit.Combinators
+import Control.Lens
+import Data.Conduit
+import Data.Monoid                                        ((<>))
+import Data.Time.Clock.POSIX
+import Data.Word
+import HaskellWorks.Data.BalancedParens.Simple
+import HaskellWorks.Data.Bits.BitShown
+import HaskellWorks.Data.FromByteString
+import HaskellWorks.Data.Xml.Conduit
+import HaskellWorks.Data.Xml.Conduit.Blank
+import HaskellWorks.Data.Xml.Succinct.Cursor.BlankedXml
+import HaskellWorks.Data.Xml.Succinct.Cursor.InterestBits
+import Prelude                                            as P
+
+import qualified Data.ByteString                                      as BS
+import qualified Data.Vector.Storable                                 as DVS
+import qualified HaskellWorks.Data.Xml.Succinct.Cursor.BalancedParens as CBP
+
+indexMain :: IndexOptions -> IO ()
+indexMain opt = case opt ^. optIndexMethod of
+  IndexInMemory -> indexInMemory  opt
+  IndexBlank    -> indexBlank     opt
+  IndexBp       -> indexBp        opt
+
+indexInMemory :: IndexOptions -> IO ()
+indexInMemory opt = do
+  let filename = opt ^. optFilename
+
+  putStrLn $ "Indexing in memory: " <> show filename
+
+  !timeA  <- getPOSIXTime
+  !textBs <- BS.readFile filename
+
+  let !blankedXml = fromByteString textBs :: BlankedXml
+  !timeB <- getPOSIXTime
+  putStrLn $ "Produced blanked XML in " <> show (timeB - timeA)
+
+  let !_ = getXmlInterestBits       (fromBlankedXml blankedXml) :: BitShown (DVS.Vector Word64)
+  !timeC <- getPOSIXTime
+  putStrLn $ "Produced interest bits in " <> show (timeC - timeB)
+
+  let !_ = CBP.getXmlBalancedParens (fromBlankedXml blankedXml) :: SimpleBalancedParens (DVS.Vector Word64)
+  !timeD <- getPOSIXTime
+  putStrLn $ "Produced balanced parens in " <> show (timeD - timeC)
+
+  return ()
+
+indexBp :: IndexOptions -> IO ()
+indexBp opt = do
+  let filename = opt ^. optFilename
+
+  putStrLn $ "Indexing via file: " <> show filename
+
+  !timeA  <- getPOSIXTime
+
+  runConduitRes
+    $   sourceFileBS filename
+    .|  blankXml
+    .|  blankedXmlToBalancedParens2
+    .|  compressWordAsBit
+    .|  sinkFileBS (filename <> ".bp")
+
+  !timeB <- getPOSIXTime
+  putStrLn $ "Produced blanked XML in " <> show (timeB - timeA)
+
+indexBlank :: IndexOptions -> IO ()
+indexBlank opt = do
+  let filename = opt ^. optFilename
+
+  putStrLn $ "Indexing via file: " <> show filename
+
+  !timeA  <- getPOSIXTime
+
+  runConduitRes
+    $   sourceFileBS filename
+    .|  blankXml
+    .|  sinkFileBS (filename <> ".blank")
+
+  !timeB <- getPOSIXTime
+  putStrLn $ "Produced blanked XML in " <> show (timeB - timeA)

--- a/src/App/Kafka.hs
+++ b/src/App/Kafka.hs
@@ -12,7 +12,7 @@ import Data.Monoid                  ((<>))
 import Kafka.Conduit
 
 
-mkConsumer :: MonadResource m => Options -> m KafkaConsumer
+mkConsumer :: MonadResource m => ServiceOptions -> m KafkaConsumer
 mkConsumer opts =
   let props = consumerBrokersList [opts ^. optKafkaBroker]
               <> groupId (opts ^. optKafkaGroupId)
@@ -23,7 +23,7 @@ mkConsumer opts =
       cons = newConsumer props sub >>= either throwM return
    in snd <$> allocate cons (void . closeConsumer)
 
-mkProducer :: MonadResource m => Options -> m KafkaProducer
+mkProducer :: MonadResource m => ServiceOptions -> m KafkaProducer
 mkProducer opts =
   let props = producerBrokersList [opts ^. optKafkaBroker]
               <> producerSuppressDisconnectLogs

--- a/stack.yaml
+++ b/stack.yaml
@@ -16,7 +16,7 @@ packages:
   extra-dep: true
 - location:
     git: git@github.com:haskell-works/hw-xml.git
-    commit: 56eea4d6687a34e3beddf5bcb3c8c8c1456889c3
+    commit: 0e0f72e9416535a94e0dc5e08936e75242783f6c
   extra-dep: true
 - location:
     git: git@github.com:haskell-works/hw-hedgehog.git
@@ -38,7 +38,7 @@ extra-deps:
   - hw-kafka-conduit-1.1.4
   - hw-parser-0.0.0.2
   - hw-prim-0.4.0.3
-  - hw-rankselect-0.8.0.1
+  - hw-rankselect-0.8.0.2
   - hw-rankselect-base-0.2.0.0
   - pure-zlib-0.6
 


### PR DESCRIPTION
This is useful for profiling.

The service is now run by:

```
attackstream-indexer service ....
```

The local indexer is now run by:

```
attackstream-indexer index ....
```

Example run of the local indexer:

```
16:16 $ time stack exec -- attackstream-indexer index --filename ./arbor-stats-B1599C.68.87.85.68-22.xml
Indexing: "./arbor-stats-B1599C.68.87.85.68-22.xml"
Produced blanked XML in 0.335536s
Produced interest bits in 10.062808s
Produced balanced parens in 1.972447s

real	0m12.741s
user	0m11.660s
sys	0m1.085s
```