### PR TITLE
Upgrade libraries and set timeout to infinite

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -20,7 +20,7 @@ import Control.Monad.Trans.AWS
 import Data.Conduit
 import HaskellWorks.Data.Conduit.Combinator
 import Kafka.Avro                           (schemaRegistry)
-import Kafka.Conduit.Sink
+import Kafka.Consumer
 import System.Environment
 import System.IO                            (stdout)
 

--- a/app/Service.hs
+++ b/app/Service.hs
@@ -8,7 +8,7 @@ import Control.Monad.Catch                  (throwM)
 import Data.Conduit
 import Data.Semigroup                       ((<>))
 import HaskellWorks.Data.Conduit.Combinator
-import Kafka.Conduit.Sink
+import Kafka.Consumer.Types
 import Network.AWS                          (MonadAWS)
 import Network.StatsD.Datadog               hiding (encodeValue)
 import Network.StatsD.Monad
@@ -17,10 +17,10 @@ import App
 import App.FileChange
 import App.XmlIndexFile
 
-import qualified App.Submissions      as S
-import qualified Data.Conduit.List    as L
-import qualified Data.Text            as T
-import Network.AWS.S3
+import qualified App.Submissions   as S
+import qualified Data.Conduit.List as L
+import qualified Data.Text         as T
+import           Network.AWS.S3
 
 extractFound :: MonadLogger m => Conduit S.SubmissionResult m S.Submission
 extractFound = awaitForever $ \x -> case x of

--- a/circle.yml
+++ b/circle.yml
@@ -3,7 +3,7 @@ jobs:
   build:
     working_directory: ~/attackstream-indexer
     docker:
-      - image: fpco/stack-build:latest
+      - image: quay.io/haskell_works/stack-build-python
 
     environment:
       LD_LIBRARY_PATH: /usr/local/lib

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,11 +1,7 @@
-resolver: lts-8.23
+resolver: lts-9.17
 
 packages:
 - '.'
-- location:
-    git: git@github.com:haskell-works/hw-haskell-avro.git
-    commit: c2169b9128ef0eedc15dc0fdac76b181a7666960
-  extra-dep: true
 - location:
     git: git@github.com:packetloop/datadog.git
     commit: d7c5b246e02677596ca03bf699c490d0c4470066
@@ -18,24 +14,22 @@ packages:
     git: git@github.com:haskell-works/hw-xml.git
     commit: 18aa15f3818d67e610f592217bdf4f0192f1ee90
   extra-dep: true
-- location:
-    git: git@github.com:haskell-works/hw-hedgehog.git
-    commit: 0fd750bbbf733045027e1bc4a61f2b0df63591c7
-  extra-dep: true
 
 # Dependency packages to be pulled from upstream that are not in the resolver
 # (e.g., acme-missiles-0.3)
 extra-deps:
+  - avro-0.2.0.0
   - hedgehog-0.5
   - hw-balancedparens-0.2.0.0
   - hw-bits-0.6.0.0
   - hw-conduit-0.2.0.1
   - hw-excess-0.2.0.0
+  - hw-hedgehog-0.1.0.1
   - hw-hspec-hedgehog-0.1.0.0
   - hw-int-0.0.0.1
-  - hw-kafka-avro-1.1.0
-  - hw-kafka-client-1.1.4
-  - hw-kafka-conduit-1.1.4
+  - hw-kafka-avro-1.3.0
+  - hw-kafka-client-2.2.0
+  - hw-kafka-conduit-2.0.0
   - hw-parser-0.0.0.2
   - hw-prim-0.4.0.3
   - hw-rankselect-0.10.0.1


### PR DESCRIPTION
## Changes
Updated libraries and added `sendTimeout 0` to prevent messages from being dropped by the producer when Kafka is offline